### PR TITLE
Fixed bug so now the client gets the actual current text on connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 # The following files are generated/updated by Hilla
 node_modules/
 src/main/frontend/generated/
+src/main/bundles/
 vite.generated.ts
 .DS_Store
 **/.DS_Store

--- a/src/main/frontend/themes/editor/styles.css
+++ b/src/main/frontend/themes/editor/styles.css
@@ -107,3 +107,31 @@
     background-color: transparent;
     color: white;
 }
+
+@media print {
+	.text-editor,
+	.header-bar,
+	.sidebar {
+		visibility: hidden !important;
+	}
+
+	.html-render {
+		margin: 1in;
+		width: 100%;
+		height: auto;
+		position: absolute;
+		left: 0;
+		top: 0;
+		page-break-after: avoid;
+	}
+
+	@page {
+		size: auto;
+		margin: 0;
+	}
+
+	body {
+		margin: 0;
+		padding: 0;
+	}
+}

--- a/src/main/frontend/themes/editor/styles.css
+++ b/src/main/frontend/themes/editor/styles.css
@@ -145,9 +145,10 @@
 .text-editor::placeholder {
     color: #999;  
     font-size: 20px; 
-  }
+}
 
-  @media print {
+
+@media print {
 	.text-editor,
 	.header-bar,
 	.sidebar {

--- a/src/main/frontend/views/@layout.tsx
+++ b/src/main/frontend/views/@layout.tsx
@@ -38,7 +38,7 @@ export default function MainLayout() {
   const location = useLocation();
 
   const [enabled, setEnabled] = useState(false);
-  const WEBSOCKET_URL = "ws://localhost:8080/create-ws-connection";
+  const WEBSOCKET_URL = "ws://" + window.location.host + "/create-ws-connection";
 
   // useEffect(() => {
   //   vaadin.documentTitleSignal.value = currentTitle;

--- a/src/main/java/org/vaadin/editor/presence/PresenceManager.java
+++ b/src/main/java/org/vaadin/editor/presence/PresenceManager.java
@@ -2,6 +2,10 @@ package org.vaadin.editor.presence;
 
 import java.util.HashSet;
 
+import org.vaadin.editor.models.ParserResponseMessage;
+import org.vaadin.editor.models.TextMessage;
+import org.vaadin.editor.parser.Parser;
+
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 import com.vaadin.hilla.BrowserCallable;
 
@@ -35,5 +39,16 @@ public class PresenceManager {
 
 	public int generateUserId() {
 		return PresenceManager.userCount;
+	}
+
+	public ParserResponseMessage getInitialText(int userId) {
+		String text = PresenceManager.getGlobalText();
+		System.out.println("user " + userId + " connected, sending text: '" + text + "'");
+		TextMessage message = new TextMessage(text, userId);
+		Parser parser = new Parser(text);
+		parser.parse();
+		ParserResponseMessage response = new ParserResponseMessage(message, parser.convertToHtml());
+
+		return response;
 	}
 }


### PR DESCRIPTION
Fixed a bug where a new client would get a blank input buffer instead of the actual text that's on the server. If they started typing, it would remove whatever anyone else typed. Now when a client connects, it will request the current text from the server and update the UI to show that instead. 

Also made it so that the websocket URL uses the actual host URL instead of hardcoding it to `localhost`. This allows it to work on AWS